### PR TITLE
Uplift

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,6 @@ Additions
 
 -  Run tests in a temporary directory so that artifacts aren't left in the current working directory
 
-
 0.8.6 - 2018-03-03
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -119,12 +119,12 @@ changes. For other changes, please open an issue on the repository's issue track
 .. |quality| image:: https://img.shields.io/scrutinizer/g/mandeep/Mausoleum.svg
     :target: https://scrutinizer-ci.com/g/mandeep/Mausoleum/
 .. |pypiversion| image:: https://img.shields.io/pypi/v/mausoleum.svg 
-    :target: https://pypi.python.org/pypi/mausoleum/
+    :target: https://pypi.org/project/mausoleum/
 .. |pypistatus| image:: https://img.shields.io/pypi/status/mausoleum.svg 
-    :target: https://pypi.python.org/pypi/mausoleum/
+    :target: https://pypi.org/project/mausoleum/
 .. |pythonversion| image:: https://img.shields.io/pypi/pyversions/mausoleum.svg 
-    :target: https://pypi.python.org/pypi/mausoleum/
+    :target: https://pypi.org/project/mausoleum/
 .. |pypiformat| image:: https://img.shields.io/pypi/format/mausoleum.svg
-    :target: https://pypi.python.org/pypi/mausoleum/
+    :target: https://pypi.org/project/mausoleum/
 .. |license| image:: https://img.shields.io/pypi/l/mausoleum.svg
-    :target: https://pypi.python.org/pypi/mausoleum/
+    :target: https://pypi.org/project/mausoleum/

--- a/mausoleum/application.py
+++ b/mausoleum/application.py
@@ -62,6 +62,7 @@ class CreateTomb(QWidget):
         self.size_box.setMaximum(999999)
         self.size_box.setMinimum(10)
         self.size_box.setFixedWidth(100)
+        size_box_label.setBuddy(self.size_box)
         size_box_layout.addWidget(size_box_label)
         size_box_layout.addWidget(self.size_box)
         size_box_layout.setSpacing(0)
@@ -70,6 +71,7 @@ class CreateTomb(QWidget):
         kdf_box_label = QLabel('KDF Iterations:')
         self.kdf_box = QSpinBox()
         self.kdf_box.setFixedWidth(100)
+        kdf_box_label.setBuddy(self.kdf_box)
         kdf_box_layout.addWidget(kdf_box_label)
         kdf_box_layout.addWidget(self.kdf_box)
 
@@ -360,6 +362,7 @@ class ResizeTomb(QWidget):
         self.size_box.setMaximum(999999)
         self.size_box.setMinimum(10)
         self.size_box.setFixedWidth(100)
+        size_box_label.setBuddy(self.size_box)
         size_box_layout.addWidget(size_box_label)
         size_box_layout.addWidget(self.size_box)
         size_box_layout.setSpacing(0)

--- a/mausoleum/application.py
+++ b/mausoleum/application.py
@@ -78,21 +78,11 @@ class CreateTomb(QWidget):
         spinbox_layout.addLayout(kdf_box_layout)
         spinbox_layout.setAlignment(Qt.AlignLeft)
 
-        open_checkbox_layout = QHBoxLayout()
-        open_checkbox_label = QLabel('Open Upon Creation:')
-        self.open_checkbox = QCheckBox()
-        open_checkbox_layout.addWidget(open_checkbox_label)
-        open_checkbox_layout.addWidget(self.open_checkbox)
-
-        random_checkbox_layout = QHBoxLayout()
-        random_checkbox_label = QLabel('Random Integer Key:')
-        self.random_checkbox = QCheckBox()
-        random_checkbox_layout.addWidget(random_checkbox_label)
-        random_checkbox_layout.addWidget(self.random_checkbox)
-
         checkbox_layout = QVBoxLayout()
-        checkbox_layout.addLayout(open_checkbox_layout)
-        checkbox_layout.addLayout(random_checkbox_layout)
+        self.open_checkbox = QCheckBox('Open Upon Creation')
+        self.random_checkbox = QCheckBox('Random Integer Key')
+        checkbox_layout.addWidget(self.open_checkbox)
+        checkbox_layout.addWidget(self.random_checkbox)
         checkbox_layout.setAlignment(Qt.AlignLeft)
 
         parameters_layout = QHBoxLayout()
@@ -217,14 +207,9 @@ class OpenTomb(QWidget):
 
         parameters_group = QGroupBox('Mount Options')
 
-        read_only_layout = QHBoxLayout()
-        read_only_label = QLabel('Read Only:')
-        self.read_only_checkbox = QCheckBox()
-        read_only_layout.addWidget(read_only_label)
-        read_only_layout.addWidget(self.read_only_checkbox)
-
         checkbox_layout = QVBoxLayout()
-        checkbox_layout.addLayout(read_only_layout)
+        self.read_only_checkbox = QCheckBox('Read Only')
+        checkbox_layout.addWidget(self.read_only_checkbox)
         checkbox_layout.setAlignment(Qt.AlignLeft)
 
         parameters_layout = QHBoxLayout()
@@ -383,14 +368,9 @@ class ResizeTomb(QWidget):
         spinbox_layout.addLayout(size_box_layout)
         spinbox_layout.setAlignment(Qt.AlignLeft)
 
-        open_checkbox_layout = QHBoxLayout()
-        open_checkbox_label = QLabel('Open Upon Resize:')
-        self.open_checkbox = QCheckBox()
-        open_checkbox_layout.addWidget(open_checkbox_label)
-        open_checkbox_layout.addWidget(self.open_checkbox)
-
         checkbox_layout = QVBoxLayout()
-        checkbox_layout.addLayout(open_checkbox_layout)
+        self.open_checkbox = QCheckBox('Open Upon Resize')
+        checkbox_layout.addWidget(self.open_checkbox)
         checkbox_layout.setAlignment(Qt.AlignLeft)
 
         parameters_layout = QHBoxLayout()

--- a/mausoleum/application.py
+++ b/mausoleum/application.py
@@ -716,3 +716,7 @@ def main():
     window.show()
     window.move(width, height)
     sys.exit(application.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/mausoleum/wrapper.py
+++ b/mausoleum/wrapper.py
@@ -292,6 +292,13 @@ def enter(name, key, password):
 
 @cli.command()
 @click.argument('name')
+def leave(name):
+    """Close a currently open tomb."""
+    close_tomb(name=name)
+
+
+@cli.command()
+@click.argument('name')
 @click.argument('size')
 @click.argument('key', required=False, default=None)
 @click.option('--password', prompt=True, hide_input=True, confirmation_prompt=False)
@@ -341,3 +348,17 @@ def etch(image, key, password):
 def resurrect(image, password):
     """Print to stdout a tomb key that's embedded in a JPEG image."""
     exhume_tomb(image, password)
+
+
+@cli.command(name='list')
+def list_cmd():
+    """Lists all known tombs."""
+    tombs = list_tombs()
+    for tomb in tombs:
+        print(tomb)
+
+
+@cli.command()
+def escape():
+    """Slams shut all open tombs."""
+    slam_tombs()

--- a/mausoleum/wrapper.py
+++ b/mausoleum/wrapper.py
@@ -98,7 +98,7 @@ def construct_tomb(name, size, key, password, debug=False):
             lock_tomb(name, key, password)
 
 
-def open_tomb(name, key, password, path='tomb', read_only=False, sudo=None):
+def open_tomb(name, key, password, path='tomb', read_only=False, sudo=None, mountpoint=None):
     """Open a tomb container with the given key.
 
     Positional arguments:
@@ -107,12 +107,15 @@ def open_tomb(name, key, password, path='tomb', read_only=False, sudo=None):
     password -- the password of the container's key
 
     Keyword arguments:
+    mountpoint -- where to mount the tomb
     path -- the path to the tomb executable
     read_only -- mount the tomb as read only
     sudo -- the sudo password of the current admin, default is None
     """
     arguments = ['sudo', '--stdin', path, 'open', '--unsafe',
-                 '--tomb-pwd', password, name, '-k', key]
+                 '--tomb-pwd', password, '-k', key, name]
+    if mountpoint:
+        arguments.append(mountpoint)
     if read_only:
         arguments.extend(['-o', 'ro'])
 
@@ -278,7 +281,8 @@ def construct(name, size, key, password, open):
 @click.argument('name')
 @click.argument('key', required=False, default=None)
 @click.option('--password', prompt=True, hide_input=True, confirmation_prompt=False)
-def enter(name, key, password):
+@click.option('--mountpoint', default=None)
+def enter(name, key, password, mountpoint):
     """Open an existing tomb container.
 
     The default key name is the name of the tomb with .key as the suffix. If the
@@ -287,7 +291,7 @@ def enter(name, key, password):
     if key is None:
         key = '{}.key' .format(name)
 
-    open_tomb(name, key, password)
+    open_tomb(name, key, password, mountpoint=mountpoint)
 
 
 @cli.command()


### PR DESCRIPTION
- Add some entries to the gitignore file to ease development
- Add new 'leave' command to close an open tomb
- Add new 'list' command, which lists all known tombs
- Add new 'escape' command, which slams shut all open tombs
- Add new '--mountpoint' flag to the 'enter' command, to expose some existing tomb functionality
- Implemented some minor usability improvements to the GUI with regards to labels being associated with form elements
- Update some links in the readme
- Remove an unnecessary blank line from the changelog

Closes #5 
Closes #6 